### PR TITLE
Updated CLI and Templates

### DIFF
--- a/tenint/__init__.py
+++ b/tenint/__init__.py
@@ -2,4 +2,4 @@ from .models.credentials import Credential, TenableVMCredential, TenableSCCreden
 from .models.configuration import Configuration, Settings  # noqa F401
 from .connector import Connector  # noqa F401
 
-__version__ = "0.9.0"
+__version__ = '0.9.1'

--- a/tenint/cli.py
+++ b/tenint/cli.py
@@ -12,124 +12,127 @@ from tenint.models.marketplace import MarketplaceConnector
 from tenint.models.pyproject import PyProject
 
 console = Console()
-tmpl = Path(os.path.dirname(__file__)).joinpath('templates')
+tmpl = Path(os.path.dirname(__file__)).joinpath("templates")
 app = Typer()
 
 
-@app.command('init')
+@app.command("init")
 def init_connector(
     path: Annotated[
-        Path, Option(help='initialization path', dir_okay=True, file_okay=False)
-    ] = Path('.'),
+        Path, Option(help="initialization path", dir_okay=True, file_okay=False)
+    ] = Path("."),
 ):
     is_dirty = False
-    for fn in ('pyproject.toml', 'connector.py'):
+    for fn in ("pyproject.toml", "connector.py"):
         src = tmpl.joinpath(fn)
         dest = path.joinpath(fn)
 
         if dest.exists():
             console.print(
-                f'[yellow bold]WARNING[/yellow bold]: skipped '
-                f'existing [cyan]{dest}[/cyan] as it already exists'
+                f"[yellow bold]WARNING[/yellow bold]: skipped "
+                f"existing [cyan]{dest}[/cyan] as it already exists"
             )
             is_dirty = True
         else:
-            with src.open('rb') as sobj, dest.open('wb') as dobj:
+            with src.open("rb") as sobj, dest.open("wb") as dobj:
                 dobj.write(sobj.read())
 
-    tests = path.joinpath('tests')
+    tests = path.joinpath("tests")
     if not tests.exists():
         tests.mkdir()
-        src = tmpl.joinpath('test_connector.py')
-        dest = tests.joinpath('test_connector.py')
-        with dest.open('wb') as dobj, src.open('rb') as sobj:
+        src = tmpl.joinpath("test_connector.py")
+        dest = tests.joinpath("test_connector.py")
+        with dest.open("wb") as dobj, src.open("rb") as sobj:
             dobj.write(sobj.read())
     else:
         console.print(
-            '[yellow bold]NOTE[/yellow bold]: skipped adding tests.  tests folder exists.'
+            "[yellow bold]NOTE[/yellow bold]: skipped adding tests.  tests folder exists."
         )
 
     console.print(
         Panel(
-            'Now that you have an initialized tenint connector, please review the '
-            'files that have been created for your next steps.\n\n'
-            '- [bold cyan]pyproject.toml[/bold cyan] contains the project '
-            ' requirements and is used to build the marketplace files\n'
-            '- [bold cyan]connector.py[/bold cyan] is a sample connector '
-            'to get you started.  It contains some example settings, a '
-            'credential example, and a sample function.',
-            title='[bold cyan]Tenable Integration Framework Connector[/bold cyan]',
+            "Now that you have an initialized tenint connector, please review the "
+            "files that have been created for your next steps.\n\n"
+            "- [bold cyan]pyproject.toml[/bold cyan] contains the project "
+            " requirements and is used to build the marketplace files\n"
+            "- [bold cyan]connector.py[/bold cyan] is a sample connector "
+            "to get you started.  It contains some example settings, a "
+            "credential example, and a sample function.",
+            title="[bold cyan]Tenable Integration Framework Connector[/bold cyan]",
         )
     )
     if is_dirty:
         console.print(
             Panel(
-                'Could not initialize all of the files as some appeared to already '
-                'exist.  Any files that previously existed were not modified.  '
-                'Recommend manually reviewing your project to ensure everything '
-                'looks correct.',
-                title='[bold red]Dirty Environment Warning[/bold red]',
-                style='yellow',
+                "Could not initialize all of the files as some appeared to already "
+                "exist.  Any files that previously existed were not modified.  "
+                "Recommend manually reviewing your project to ensure everything "
+                "looks correct.",
+                title="[bold red]Dirty Environment Warning[/bold red]",
+                style="yellow",
             )
         )
 
 
-@app.command('build')
+@app.command("build")
 def build_connector(
-    path: Annotated[Path, Option(help='connector code path')] = Path('.'),
-    platform: Annotated[str | None, Option(help='platform to build to')] = None,
+    path: Annotated[Path, Option(help="connector code path")] = Path("."),
+    platform: Annotated[str | None, Option(help="platform to build to")] = None,
     tag: Annotated[
         str | None,
-        Option(
-            help='Tag for the fimal image.  Defaults to the image settings if unspecified.'
-        ),
+        Option(help="Tag for the fimal image. defaults to the project name."),
     ] = None,
     cleanup: Annotated[
-        bool | None, Option(help='auto-remove any generated build files?')
+        bool | None, Option(help="auto-remove any generated build files?")
     ] = None,
 ):
-    tmpldfile = tmpl.joinpath('Dockerfile')
-    dockerfile = path.joinpath('Dockerfile')
-    pyproject = path.joinpath('pyproject.toml')
+    tmpldfile = tmpl.joinpath("Dockerfile")
+    dockerfile = path.joinpath("Dockerfile")
+    pyproject = path.joinpath("pyproject.toml")
 
     if not tag:
-        with pyproject.open('rb') as pf:
+        with pyproject.open("rb") as pf:
             project = PyProject(**tomllib.load(pf))
-            tag = project.tool.tenint.connector.images.amd64
+            tag = project.project.name
 
     if not dockerfile.exists():
-        with tmpldfile.open('rb') as src, dockerfile.open('wb') as dst:
+        with tmpldfile.open("rb") as src, dockerfile.open("wb") as dst:
             dst.write(src.read())
             cleanup = True if cleanup is None else cleanup
 
     builder = subprocess.Popen(
-        ['docker', 'build', '-t', tag, path],
+        ["docker", "build", "-t", tag, path],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
     for line in builder.stdout:
-        console.out(line.decode('utf-8').strip('\n'))
+        console.out(line.decode("utf-8").strip("\n"))
 
     if cleanup:
         dockerfile.unlink()
 
 
-@app.command('marketplace')
+@app.command("marketplace")
 def gen_marketplace(
-    image: Annotated[
-        str, Option(..., help='Docker Image Name')
-    ] = 'local/connector-example',
+    image: Annotated[str, Option(..., help="Docker Image Name")] = None,
     icon: Annotated[
-        str, Option(..., help='Icon Image URL')
-    ] = 'https://nourl.example/logo.svg',
-    path: Annotated[Path, Option(help='connector code path')] = Path('.'),
-    output: Annotated[Path, Option(help='output marketplace json file')] = None,
+        str, Option(..., help="Icon Image URL")
+    ] = "https://nourl.example/logo.svg",
+    path: Annotated[Path, Option(help="connector code path")] = Path("."),
+    output: Annotated[Path, Option(help="output marketplace json file")] = None,
 ):
-    mpfile = path.joinpath('marketplace-object.json')
+    pyproject_file = path.joinpath("pyproject.toml")
+    with pyproject_file.open("rb") as fobj:
+        project = PyProject(**tomllib.load(fobj))
+
+    if not image:
+        image = project.project.name
+
+    mpfile = path.joinpath("marketplace-object.json")
     mp = MarketplaceConnector.load_from_pyproject(
-        filename='pyproject.toml', image_url=image, icon_url=icon
-    ).model_dump(mode='json')
+        filename=project, image_url=image, icon_url=icon
+    ).model_dump(mode="json")
     console.print(mp)
     if output:
-        with mpfile.open('w', encoding='utf-8') as fobj:
+        with mpfile.open("w", encoding="utf-8") as fobj:
             fobj.write(mp.model_dump_json())

--- a/tenint/templates/Dockerfile
+++ b/tenint/templates/Dockerfile
@@ -1,25 +1,37 @@
-FROM python:3.12-alpine AS build
-RUN pip install uv && uv pip install --system tenint
-RUN addgroup -S connector && adduser connector -S -G connector -h /connector
+FROM python:3.12-alpine AS connector-base
 
-ADD --chown=connector:connector ./ /connector/
+ARG UV_SYSTEM_PYTHON=true
+RUN pip install uv && uv pip install tenint
 
-RUN uv pip install --system -r /connector/pyproject.toml
+
+FROM connector-base AS build
+ADD ./ /connector/
+RUN uv pip install -r /connector/pyproject.toml
 
 
 FROM build AS test
 WORKDIR /connector/
-RUN uv pip install --system "tenint[testing]" \
- && uv pip install --system --extra testing -r /connector/pyproject.toml
+RUN uv pip install "tenint[testing]" \
+ && uv pip install --extra testing -r /connector/pyproject.toml
 RUN ruff check
-RUN python -m pytest
+RUN python -m pytest --cov-fail-under=80
 RUN uv export --format requirements-txt | uv tool run pip-audit
 RUN uv tool run \
     --with "bandit[toml,baseline,sarif]" \
     bandit -c pyproject.toml -r . -ll
 RUN tenint marketplace
+RUN echo $(date '+Y-%m-%d %H:%M%S') > /tested_on
 
-FROM build AS release
+
+FROM python:3.12-alpine
+
+RUN addgroup -S connector && adduser connector -S -G connector -h /connector
+USER connector:connector
 WORKDIR /connector/
-COPY --from=test --chown=connector:connector /connector/marketplace.json marketplace.json
+
+COPY --from=connector-base /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages 
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages 
+COPY --from=build --chown=connector:connector /connector /connector
+COPY --from=test --chown=connector:connector /tested_on /tested_on
+
 ENTRYPOINT ["python", "connector.py"]

--- a/tenint/templates/test_connector.py
+++ b/tenint/templates/test_connector.py
@@ -1,0 +1,13 @@
+import connector
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_connector_run():
+    result = runner.invoke(
+        connector.connector.app, ["run", "-l", "INFO", "-j", '{"is_bool": true}']
+    )
+    print(result.stdout)
+    assert result.exit_code == 0
+    assert "hello world" in result.stdout


### PR DESCRIPTION
# Description

- Updated `marketplace` command to more correctly output the marketplace object
- Updated `build` command to work with the updated data models.
- Updated the vendored `Dockerfile` to more closely resemble the one used in the mono-repo
- Added some defauly tests in the vendoered example templates to enable the ability to run all three CLI commands with
  just the example.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Manual testing of the CLI with the updated templates.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
